### PR TITLE
Support many databases (fixes #4)

### DIFF
--- a/src/Listeners/LogRouteUsage.php
+++ b/src/Listeners/LogRouteUsage.php
@@ -3,6 +3,7 @@
 namespace Julienbourdeau\RouteUsage\Listeners;
 
 use Illuminate\Support\Facades\DB;
+use Julienbourdeau\RouteUsage\RouteUsage;
 
 class LogRouteUsage
 {
@@ -25,14 +26,16 @@ class LogRouteUsage
         }
 
         $identifier = sha1($method.$path.$action.$status_code);
-        $date = date('Y-m-d H:i:s');
+        $date = now();
 
-        DB::statement(
-            "INSERT INTO route_usage
-                    (`identifier`, `method`, `path`, `status_code`, `action`, `created_at`, `updated_at`)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
-                ON DUPLICATE KEY UPDATE `updated_at` = '{$date}'",
-            [$identifier, $method, $path, $status_code, $action, $date, $date]
-        );
+        RouteUsage::updateOrCreate([
+            'identifier' => $identifier
+        ], [
+            'method' => $method,
+            'path' => $path,
+            'status_code' => $status_code,
+            'action' => $action,
+            'updated_at' => $date
+        ]);
     }
 }

--- a/src/RouteUsage.php
+++ b/src/RouteUsage.php
@@ -11,6 +11,7 @@ class RouteUsage extends Model
     protected static $unguarded = true;
 
     protected $casts = [
+        'created_at' => 'datetime',
         'updated_at' => 'datetime',
     ];
 }

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -54,7 +54,7 @@ class IntegrationTest extends BaseIntegrationTestCase
             'path' => '/',
             'status_code' => 200,
             'updated_at' => ($now = now()->subYear(1)),
-            'created_at' => $created_at = $now->format('Y-m-d H:i:s'),
+            'created_at' => ($created_at = $now),
         ]);
 
         Route::get('/', function () {
@@ -66,6 +66,6 @@ class IntegrationTest extends BaseIntegrationTestCase
 
         $route = RouteUsage::where('identifier', $id)->first();
         $this->assertGreaterThan(time() - 120, $route->updated_at->getTimestamp());
-        $this->assertEquals($created_at, $route->created_at);
+        $this->assertEquals($created_at->format('Y-m-d H:i:s'), $route->created_at->format('Y-m-d H:i:s'));
     }
 }


### PR DESCRIPTION
Hi!

I had to make a modification to one test as other databases won't necessarily insert a timestamp with microseconds. If that's not acceptable I understand.

If you want to test, my phpunit.xml was configured as:
```xml
<env name="DB_CONNECTION" value="sqlite"/>
<env name="DB_DATABASE" value=":memory:"/>
```

Fixes #4 
Might also bring support for Redis?