### PR TITLE
Ignore routes based on name or uri

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Exclude requests based on route name or uri
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify which of the database connections below you wish
+    | to use as your default connection for all database work. Of course
+    | you may use many connections at once using the Database library.
+    |
+    */
+
+    'excluding-regex' => [
+        'name' => '/^(route-usage\.|nova\.)/',
+        'uri' => ''
+    ],
+];

--- a/src/Listeners/LogRouteUsage.php
+++ b/src/Listeners/LogRouteUsage.php
@@ -8,24 +8,11 @@ class LogRouteUsage
 {
     public function handle($event)
     {
-        $status_code = $event->response->getStatusCode();
-
-        if ($status_code >= 400 || $status_code < 200) {
+        if (!$this->shouldLogUsage($event)) {
             return;
         }
 
-        $method = $event->request->getMethod();
-        $path = $event->request->route()->uri ?? $event->request->getPathInfo();
-        $action = optional($event->request->route())->getAction()['uses'];
-
-        if ($action instanceof \Closure) {
-            $action = '[Closure]';
-        } elseif (!is_string($action) && !is_null($action)) {
-            $action = '[Unsupported]';
-        }
-
-        $identifier = sha1($method.$path.$action.$status_code);
-        $date = date('Y-m-d H:i:s');
+        extract($this->extractAttributes($event));
 
         DB::statement(
             "INSERT INTO route_usage
@@ -34,5 +21,48 @@ class LogRouteUsage
                 ON DUPLICATE KEY UPDATE `updated_at` = '{$date}'",
             [$identifier, $method, $path, $status_code, $action, $date, $date]
         );
+    }
+
+    protected function shouldLogUsage($event)
+    {
+        $status_code = $event->response->getStatusCode();
+
+        if ($status_code >= 400 || $status_code < 200) {
+            return;
+        }
+
+        $route = $event->request->route();
+        $regex = config('route-usage.excluding-regex');
+
+        if (isset($regex['name']) && $regex['name'] && preg_match($regex['name'], $route->getName())) {
+            return false;
+        }
+
+        if (isset($regex['uri']) && $regex['uri'] && preg_match($regex['uri'], $route->uri)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    protected function extractAttributes($event)
+    {
+        $path = ($route = $event->request->route()) ? $route->uri : $event->request->getPathInfo();
+        $action = $route ? $route->getAction()['uses'] : null;
+
+        if ($action instanceof \Closure) {
+            $action = '[Closure]';
+        } elseif (!is_string($action) && !is_null($action)) {
+            $action = '[Unsupported]';
+        }
+
+        return [
+            'status_code' => $status_code = $event->response->getStatusCode(),
+            'method' => $method = $event->request->getMethod(),
+            'path' => $path,
+            'action' => $action,
+            'identifier' => sha1($method.$path.$action.$status_code),
+            'date' => date('Y-m-d H:i:s'),
+        ];
     }
 }

--- a/src/RouteUsageServiceProvider.php
+++ b/src/RouteUsageServiceProvider.php
@@ -22,7 +22,10 @@ class RouteUsageServiceProvider extends ServiceProvider
         $this->loadRoutesFrom(__DIR__.'/routes.php');
 
         if ($this->app->runningInConsole()) {
-            // Registering package commands.
+            $this->publishes([
+                __DIR__.'/../config/config.php' => config_path('route-usage.php'),
+            ], 'config');
+
             $this->commands([
                 UsageRouteCommand::class,
             ]);

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -68,4 +68,24 @@ class IntegrationTest extends BaseIntegrationTestCase
         $this->assertGreaterThan(time() - 120, $route->updated_at->getTimestamp());
         $this->assertEquals($created_at, $route->created_at);
     }
+    /** @test */
+    public function itIgnoresRoutesBasedOnConfig()
+    {
+        config(['route-usage' => [
+            'excluding-regex' => [
+                'name' => '/^nope\./',
+                'uri' => '/ignore/'
+            ]
+        ]]);
+        Route::get('/', function () { return 'home'; });
+        Route::get('/ok', function () { return 'OK'; })->name('nope.index');
+        Route::get('/ignore', function () { return 'KO'; });
+
+        $this->get('/ok');
+        $this->get('/ignore');
+        $this->assertEquals(0, RouteUsage::count());
+
+        $this->get('/');
+        $this->assertEquals(1, RouteUsage::count());
+    }
 }


### PR DESCRIPTION
Introduce config file to ignore route based on:

* Route name
* Route URI

By default I'm ignoring Nova and the `/route-usage` route (from this package).

Because the goal it know which of **your routes** are used, I think it's fine to remove all packge routes (like Nova). You can't do anything about them.


Configuration:
```php
return [

    'excluding-regex' => [
        'name' => '/^(route-usage\.|nova\.)/',
        'uri' => ''
    ],

];
```