### PR TITLE
Ignore OPTIONS http calls

### DIFF
--- a/src/Listeners/LogRouteUsage.php
+++ b/src/Listeners/LogRouteUsage.php
@@ -25,10 +25,13 @@ class LogRouteUsage
 
     protected function shouldLogUsage($event)
     {
-        $status_code = $event->response->getStatusCode();
+        if ($event->request->isMethod('options')) {
+            return false;
+        }
 
+        $status_code = $event->response->getStatusCode();
         if ($status_code >= 400 || $status_code < 200) {
-            return;
+            return false;
         }
 
         $route = $event->request->route();


### PR DESCRIPTION
Based on #11 

The package ignores OPTIONS calls because they are followed by a second call, only this one matters.

I also added a test.