### PR TITLE
Protect HTML page with Gate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,6 @@ php:
 services:
     - mysql
 
-env:
-  matrix:
-    - COMPOSER_FLAGS="--prefer-lowest"
-    - COMPOSER_FLAGS=""
-
 before_install:
   - mysql -e 'CREATE DATABASE test_route_usage;'
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,6 +20,7 @@
         </whitelist>
     </filter>
     <php>
+        <env name="APP_KEY" value="base64:Vofr/3qQZXGlILQy/wZbsPb0ErpwsfnWoGHbgmlJVJw="/>
         <env name="DB_CONNECTION" value="mysql"/>
         <env name="DB_DATABASE" value="test_route_usage"/>
         <env name="DB_USERNAME" value="root"/>

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -4,10 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <!-- CSRF Token -->
-    <meta name="csrf-token" content="{{ csrf_token() }}">
-
-    <title>{{ config('app.name', 'Laravel') }}</title>
+    <title>Route Usage</title>
 
     <link href="https://unpkg.com/tailwindcss@1.1.3/dist/tailwind.min.css" rel="stylesheet">
 </head>

--- a/src/Authorize.php
+++ b/src/Authorize.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Julienbourdeau\RouteUsage;
+
+
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Gate;
+
+class Authorize
+{
+    public function handle($request, $next)
+    {
+        return $this->check($request) ? $next($request) : abort(403);
+    }
+
+    protected function check($request)
+    {
+        return App::environment('local') ||
+            Gate::check('viewRouteUsage', [$request->user()]);
+    }
+}

--- a/src/RouteUsageServiceProvider.php
+++ b/src/RouteUsageServiceProvider.php
@@ -4,6 +4,7 @@ namespace Julienbourdeau\RouteUsage;
 
 use Illuminate\Foundation\Http\Events\RequestHandled;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
 use Julienbourdeau\RouteUsage\Console\Commands\UsageRouteCommand;
 use Julienbourdeau\RouteUsage\Listeners\LogRouteUsage;
@@ -15,7 +16,9 @@ class RouteUsageServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        Event::listen(RequestHandled::class, LogRouteUsage::class);
+        $this->listen();
+
+        $this->gate();
 
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'route-usage');
         $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
@@ -30,5 +33,17 @@ class RouteUsageServiceProvider extends ServiceProvider
                 UsageRouteCommand::class,
             ]);
         }
+    }
+
+    protected function gate()
+    {
+        Gate::define('viewRouteUsage', function ($user) {
+            return false;
+        });
+    }
+
+    protected function listen()
+    {
+        Event::listen(RequestHandled::class, LogRouteUsage::class);
     }
 }

--- a/src/routes.php
+++ b/src/routes.php
@@ -2,4 +2,6 @@
 
 use Julienbourdeau\RouteUsage\Http\Controllers\RouteUsageController;
 
-Route::get('route-usage', [RouteUsageController::class, 'index'])->name('route-usage.index');
+Route::get('route-usage', [RouteUsageController::class, 'index'])
+    ->middleware(['web', \Julienbourdeau\RouteUsage\Authorize::class])
+    ->name('route-usage.index');

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -3,6 +3,7 @@
 namespace Julienbourdeau\RouteUsage\Tests;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Route;
 use Julienbourdeau\RouteUsage\RouteUsage;
 
@@ -98,5 +99,21 @@ class IntegrationTest extends BaseIntegrationTestCase
 
         $this->get('/');
         $this->assertEquals(1, RouteUsage::count());
+    }
+
+    /** @test */
+    public function itOnlyShowsHtmlPageOnLocalByDefault()
+    {
+
+        $response = $this->get(route('route-usage.index'));
+        $response->assertStatus(403);
+
+        App::shouldReceive('environment')
+            ->once()
+            ->with('local')
+            ->andReturnTrue();
+
+        $response = $this->get(route('route-usage.index'));
+        $response->assertStatus(200);
     }
 }

--- a/tests/RouteUsageControllerTest.php
+++ b/tests/RouteUsageControllerTest.php
@@ -4,6 +4,7 @@ namespace Julienbourdeau\RouteUsage\Tests;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
 use Julienbourdeau\RouteUsage\RouteUsage;
 
 /**
@@ -18,6 +19,10 @@ class RouteUsageControllerTest extends BaseIntegrationTestCase
     {
         parent::setUp();
         $this->loadFixtures();
+
+        Gate::shouldReceive('check')
+            ->with('viewRouteUsage', \Mockery::any())
+            ->andReturnTrue();
     }
 
     /** @test */


### PR DESCRIPTION
The HTML page is protected by a `Gate`. By default, it's only accessible in `local` env.

To access it in any other env, you'll have to define a gate in your `AuthServiceProvider`

```php
Gate::define('viewRouteUsage', function ($user) {
    return $user->isSuperAdmin();
});
```

Also see #7 for more ideas and conversation.