### PR TITLE
Ignore Telescope and Clockwork routes

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -14,7 +14,7 @@ return [
     */
 
     'excluding-regex' => [
-        'name' => '/^(route-usage|nova|debugbar|horizon|telescope|__clockwork)\./',
+        'name' => '/^(route-usage|nova|debugbar|horizon|telescope|telescope-api|__clockwork)\./',
         'uri' => '',
     ],
 ];

--- a/config/config.php
+++ b/config/config.php
@@ -14,7 +14,7 @@ return [
     */
 
     'excluding-regex' => [
-        'name' => '/^(route-usage|nova|debugbar|horizon)\./',
+        'name' => '/^(route-usage|nova|debugbar|horizon|telescope|__clockwork)\./',
         'uri' => '',
     ],
 ];


### PR DESCRIPTION
As proposer in https://github.com/julienbourdeau/route-usage/issues/17 this adds Telescope and Clockwork routes to the excluding regex.
The test already checks that excluding routes works, so I didn't find necessary to add a test specific to these 2 cases.