### PR TITLE
Configurable date format

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -17,4 +17,18 @@ return [
         'name' => '/^(route-usage|nova|debugbar|horizon|telescope|telescope-api|__clockwork)\./',
         'uri' => '',
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Specify date format
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify the time format used to save the route usage
+    | on the database.
+    |
+    | The value must be a valid time format.
+    |
+    */
+
+    'date-format' => 'Y-m-d H:i:s',
 ];

--- a/src/Listeners/LogRouteUsage.php
+++ b/src/Listeners/LogRouteUsage.php
@@ -61,15 +61,13 @@ class LogRouteUsage
             $action = '[Unsupported]';
         }
 
-        $date_format = config('route-usage.date-format') ?? 'Y-m-d H:i:s';
-
         return [
             'status_code' => $status_code = $event->response->getStatusCode(),
             'method' => $method = $event->request->getMethod(),
             'path' => $path,
             'action' => $action,
             'identifier' => sha1($method.$path.$action.$status_code),
-            'date' => date($date_format),
+            'date' => date(config('route-usage.date-format', 'Y-m-d H:i:s')),
         ];
     }
 }

--- a/src/Listeners/LogRouteUsage.php
+++ b/src/Listeners/LogRouteUsage.php
@@ -67,7 +67,7 @@ class LogRouteUsage
             'path' => $path,
             'action' => $action,
             'identifier' => sha1($method.$path.$action.$status_code),
-            'date' => date('Y-m-d H:i:s'),
+            'date' => date(config('route-usage.date-format')),
         ];
     }
 }

--- a/src/Listeners/LogRouteUsage.php
+++ b/src/Listeners/LogRouteUsage.php
@@ -60,6 +60,8 @@ class LogRouteUsage
         } elseif (!is_string($action) && !is_null($action)) {
             $action = '[Unsupported]';
         }
+        
+        $date_format = config('route-usage.date-format') ?? 'Y-m-d H:i:s';
 
         return [
             'status_code' => $status_code = $event->response->getStatusCode(),
@@ -67,7 +69,7 @@ class LogRouteUsage
             'path' => $path,
             'action' => $action,
             'identifier' => sha1($method.$path.$action.$status_code),
-            'date' => date(config('route-usage.date-format')),
+            'date' => date($date_format),
         ];
     }
 }

--- a/src/Listeners/LogRouteUsage.php
+++ b/src/Listeners/LogRouteUsage.php
@@ -60,7 +60,7 @@ class LogRouteUsage
         } elseif (!is_string($action) && !is_null($action)) {
             $action = '[Unsupported]';
         }
-        
+
         $date_format = config('route-usage.date-format') ?? 'Y-m-d H:i:s';
 
         return [

--- a/src/RouteUsage.php
+++ b/src/RouteUsage.php
@@ -14,4 +14,9 @@ class RouteUsage extends Model
         'created_at' => 'datetime',
         'updated_at' => 'datetime',
     ];
+
+    public function getDateFormat()	
+    {	
+        return config('route-usage.date-format', 'Y-m-d H:i:s');	
+    }
 }

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -120,7 +120,7 @@ class IntegrationTest extends BaseIntegrationTestCase
     {
 		config(['route-usage' => [
             'excluding-regex' => [],
-			'date-format' => 'Y-m-d H:i:s.u',
+            'date-format' => 'Y-m-d H:i:s.u',
         ]]);
 		
 		$response = $this->get('/');

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -114,4 +114,18 @@ class IntegrationTest extends BaseIntegrationTestCase
         $response = $this->get(route('route-usage.index'));
         $response->assertStatus(200);
     }
+
+    /** @test */
+    public function itHandlesMultipleTimeFormats()
+    {
+		config(['route-usage' => [
+            'excluding-regex' => [],
+			'date-format' => 'Y-m-d H:i:s.u',
+        ]]);
+		
+		$response = $this->get('/');
+        $response->assertStatus(200);
+
+		$this->assertEquals(1, RouteUsage::count());
+    }
 }


### PR DESCRIPTION
When using SQLServer I get a Carbon exception related to the date format.

```
Carbon\\Carbon::createFromFormat('Y-m-d H:i:s.u', '2020-03-03 14:1...')
```

This Pull Request adds the ability to specify the date format on the configuration, in order to avoid this error.

This is the full log in case you find it useful.

```
2020-03-03 14:10:08] local.ERROR: Data missing {"userId":1,"exception":"[object] (InvalidArgumentException(code: 0): Data missing at /var/www/vendor/nesbot/carbon/src/Carbon/Carbon.php:917)
[stacktrace]
#0 /var/www/vendor/laravel/framework/src/Illuminate/Support/DateFactory.php(216): Carbon\\Carbon::createFromFormat('Y-m-d H:i:s.u', '2020-03-03 14:1...')
#1 /var/www/vendor/laravel/framework/src/Illuminate/Support/Facades/Facade.php(239): Illuminate\\Support\\DateFactory->__call('createFromForma...', Array)
#2 /var/www/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php(809): Illuminate\\Support\\Facades\\Facade::__callStatic('createFromForma...', Array)
#3 /var/www/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php(831): Illuminate\\Database\\Eloquent\\Model->asDateTime('2020-03-03 14:1...')
#4 /var/www/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php(576): Illuminate\\Database\\Eloquent\\Model->fromDateTime('2020-03-03 14:1...')
#5 /var/www/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(329): Illuminate\\Database\\Eloquent\\Model->setAttribute('updated_at', '2020-03-03 14:1...')
#6 /var/www/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php(436): Illuminate\\Database\\Eloquent\\Model->fill(Array)
#7 /var/www/vendor/laravel/framework/src/Illuminate/Support/helpers.php(1124): Illuminate\\Database\\Eloquent\\Builder->Illuminate\\Database\\Eloquent\\{closure}(Object(Julienbourdeau\\RouteUsage\\RouteUsage))
#8 /var/www/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php(437): tap(Object(Julienbourdeau\\RouteUsage\\RouteUsage), Object(Closure))
#9 /var/www/vendor/laravel/framework/src/Illuminate/Support/Traits/ForwardsCalls.php(23): Illuminate\\Database\\Eloquent\\Builder->updateOrCreate(Array, Array)
#10 /var/www/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(1618): Illuminate\\Database\\Eloquent\\Model->forwardCallTo(Object(Illuminate\\Database\\Eloquent\\Builder), 'updateOrCreate', Array)
#11 /var/www/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(1630): Illuminate\\Database\\Eloquent\\Model->__call('updateOrCreate', Array)
#12 /var/www/vendor/julienbourdeau/route-usage/src/Listeners/LogRouteUsage.php(24): Illuminate\\Database\\Eloquent\\Model::__callStatic('updateOrCreate', Array)
#13 [internal function]: Julienbourdeau\\RouteUsage\\Listeners\\LogRouteUsage->handle(Object(Illuminate\\Foundation\\Http\\Events\\RequestHandled))
#14 /var/www/vendor/laravel/framework/src/Illuminate/Events/Dispatcher.php(366): call_user_func_array(Array, Array)
#15 /var/www/vendor/laravel/framework/src/Illuminate/Events/Dispatcher.php(196): Illuminate\\Events\\Dispatcher->Illuminate\\Events\\{closure}('Illuminate\\\\Foun...', Array)
#16 /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php(128): Illuminate\\Events\\Dispatcher->dispatch('Illuminate\\\\Foun...')
#17 /var/www/public/index.php(55): Illuminate\\Foundation\\Http\\Kernel->handle(Object(Illuminate\\Http\\Request))
#18 {main}
"}

```